### PR TITLE
Update to 0.20 & run black

### DIFF
--- a/1-tutorials/1-getting-started.ipynb
+++ b/1-tutorials/1-getting-started.ipynb
@@ -345,7 +345,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -359,7 +359,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/1-tutorials/10-smoothing-trajectories.ipynb
+++ b/1-tutorials/10-smoothing-trajectories.ipynb
@@ -17,7 +17,7 @@
     "\n",
     "[Documentation](https://movingpandas.readthedocs.io/en/main/api/trajectorysmoother.html)\n",
     "\n",
-    "A closely related type of operation is [trajectory generalization which is coverd in a separate notebook](./7-generalizing-trajectories.ipynb). "
+    "A closely related type of operation is [trajectory generalization which is covered in a separate notebook](./7-generalizing-trajectories.ipynb). "
    ]
   },
   {
@@ -30,7 +30,7 @@
     "import geopandas as gpd\n",
     "import movingpandas as mpd\n",
     "import shapely as shp\n",
-    "import hvplot.pandas \n",
+    "import hvplot.pandas\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from geopandas import GeoDataFrame, read_file\n",
@@ -39,11 +39,18 @@
     "from holoviews import opts, dim\n",
     "\n",
     "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
     "\n",
-    "plot_defaults = {'linewidth':5, 'capstyle':'round', 'figsize':(9,3), 'legend':True}\n",
-    "opts.defaults(opts.Overlay(active_tools=['wheel_zoom']))\n",
-    "hvplot_defaults = {'tiles':'CartoLight', 'frame_height':320, 'frame_width':320, 'cmap':'Viridis', 'colorbar':True}\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "plot_defaults = {\"linewidth\": 5, \"capstyle\": \"round\", \"figsize\": (9, 3), \"legend\": True}\n",
+    "opts.defaults(opts.Overlay(active_tools=[\"wheel_zoom\"]))\n",
+    "hvplot_defaults = {\n",
+    "    \"tiles\": \"CartoLight\",\n",
+    "    \"frame_height\": 320,\n",
+    "    \"frame_width\": 320,\n",
+    "    \"cmap\": \"Viridis\",\n",
+    "    \"colorbar\": True,\n",
+    "}\n",
     "\n",
     "mpd.show_versions()"
    ]
@@ -54,8 +61,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gdf = read_file('../data/geolife_small.gpkg')\n",
-    "tc = mpd.TrajectoryCollection(gdf, 'trajectory_id', t='t')"
+    "gdf = read_file(\"../data/geolife_small.gpkg\")\n",
+    "tc = mpd.TrajectoryCollection(gdf, \"trajectory_id\", t=\"t\")"
    ]
   },
   {
@@ -94,7 +101,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "smooth = mpd.KalmanSmootherCV(split).smooth(process_noise_std=0.1, measurement_noise_std=10)\n",
+    "smooth = mpd.KalmanSmootherCV(split).smooth(\n",
+    "    process_noise_std=0.1, measurement_noise_std=10\n",
+    ")\n",
     "print(smooth)"
    ]
   },
@@ -104,9 +113,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "kwargs = {**hvplot_defaults, 'line_width':4}\n",
-    "(split.hvplot(title='Original Trajectories', **kwargs) + \n",
-    " smooth.hvplot(title='Smooth Trajectories', **kwargs))"
+    "kwargs = {**hvplot_defaults, \"line_width\": 4}\n",
+    "(\n",
+    "    split.hvplot(title=\"Original Trajectories\", **kwargs)\n",
+    "    + smooth.hvplot(title=\"Smooth Trajectories\", **kwargs)\n",
+    ")"
    ]
   },
   {
@@ -115,10 +126,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "kwargs = {**hvplot_defaults, 'c':'speed', 'line_width':7, 'clim':(0,20)}\n",
+    "kwargs = {**hvplot_defaults, \"c\": \"speed\", \"line_width\": 7, \"clim\": (0, 20)}\n",
     "smooth.add_speed()\n",
-    "(split.trajectories[2].hvplot(title='Original Trajectory', **kwargs) + \n",
-    " smooth.trajectories[2].hvplot(title='Smooth Trajectory', **kwargs))"
+    "(\n",
+    "    split.trajectories[2].hvplot(title=\"Original Trajectory\", **kwargs)\n",
+    "    + smooth.trajectories[2].hvplot(title=\"Smooth Trajectory\", **kwargs)\n",
+    ")"
    ]
   },
   {
@@ -140,11 +153,15 @@
     "cleaned = traj.copy()\n",
     "cleaned = mpd.OutlierCleaner(cleaned).clean(alpha=2)\n",
     "\n",
-    "smoothed = mpd.KalmanSmootherCV(cleaned).smooth(process_noise_std=0.1, measurement_noise_std=10)\n",
-    "    \n",
-    "(traj.hvplot(title='Original Trajectory', **kwargs) + \n",
-    " cleaned.hvplot(title='Cleaned Trajectory', **kwargs) + \n",
-    " smoothed.hvplot(title='Cleaned & Smoothed Trajectory', **kwargs))"
+    "smoothed = mpd.KalmanSmootherCV(cleaned).smooth(\n",
+    "    process_noise_std=0.1, measurement_noise_std=10\n",
+    ")\n",
+    "\n",
+    "(\n",
+    "    traj.hvplot(title=\"Original Trajectory\", **kwargs)\n",
+    "    + cleaned.hvplot(title=\"Cleaned Trajectory\", **kwargs)\n",
+    "    + smoothed.hvplot(title=\"Cleaned & Smoothed Trajectory\", **kwargs)\n",
+    ")"
    ]
   },
   {
@@ -157,7 +174,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -171,7 +188,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/1-tutorials/11-measuring-distances.ipynb
+++ b/1-tutorials/11-measuring-distances.ipynb
@@ -30,7 +30,7 @@
     "import geopandas as gpd\n",
     "import movingpandas as mpd\n",
     "import shapely as shp\n",
-    "import hvplot.pandas \n",
+    "import hvplot.pandas\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from geopandas import GeoDataFrame, read_file\n",
@@ -39,11 +39,18 @@
     "from holoviews import opts, dim\n",
     "\n",
     "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
     "\n",
-    "plot_defaults = {'linewidth':5, 'capstyle':'round', 'figsize':(9,3), 'legend':True}\n",
-    "opts.defaults(opts.Overlay(active_tools=['wheel_zoom']))\n",
-    "hvplot_defaults = {'tiles':'CartoLight', 'frame_height':320, 'frame_width':320, 'cmap':'Viridis', 'colorbar':True}\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "plot_defaults = {\"linewidth\": 5, \"capstyle\": \"round\", \"figsize\": (9, 3), \"legend\": True}\n",
+    "opts.defaults(opts.Overlay(active_tools=[\"wheel_zoom\"]))\n",
+    "hvplot_defaults = {\n",
+    "    \"tiles\": \"CartoLight\",\n",
+    "    \"frame_height\": 320,\n",
+    "    \"frame_width\": 320,\n",
+    "    \"cmap\": \"Viridis\",\n",
+    "    \"colorbar\": True,\n",
+    "}\n",
     "\n",
     "mpd.show_versions()"
    ]
@@ -62,12 +69,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.DataFrame([\n",
-    "  {'geometry':Point(0,0), 't':datetime(2018,1,1,12,0,0)},\n",
-    "  {'geometry':Point(6,0), 't':datetime(2018,1,1,12,6,0)},\n",
-    "  {'geometry':Point(6,6), 't':datetime(2018,1,1,12,10,0)},\n",
-    "  {'geometry':Point(9,9), 't':datetime(2018,1,1,12,15,0)}\n",
-    "]).set_index('t')\n",
+    "df = pd.DataFrame(\n",
+    "    [\n",
+    "        {\"geometry\": Point(0, 0), \"t\": datetime(2018, 1, 1, 12, 0, 0)},\n",
+    "        {\"geometry\": Point(6, 0), \"t\": datetime(2018, 1, 1, 12, 6, 0)},\n",
+    "        {\"geometry\": Point(6, 6), \"t\": datetime(2018, 1, 1, 12, 10, 0)},\n",
+    "        {\"geometry\": Point(9, 9), \"t\": datetime(2018, 1, 1, 12, 15, 0)},\n",
+    "    ]\n",
+    ").set_index(\"t\")\n",
     "geo_df = GeoDataFrame(df, crs=31256)\n",
     "toy_traj = mpd.Trajectory(geo_df, 1)\n",
     "toy_traj.df"
@@ -79,18 +88,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.DataFrame([\n",
-    "  {'geometry':Point(3,3), 't':datetime(2018,1,1,12,0,0)},\n",
-    "  {'geometry':Point(3,9), 't':datetime(2018,1,1,12,6,0)},\n",
-    "  {'geometry':Point(2,9), 't':datetime(2018,1,1,12,10,0)},\n",
-    "  {'geometry':Point(0,7), 't':datetime(2018,1,1,12,15,0)}\n",
-    "]).set_index('t')\n",
+    "df = pd.DataFrame(\n",
+    "    [\n",
+    "        {\"geometry\": Point(3, 3), \"t\": datetime(2018, 1, 1, 12, 0, 0)},\n",
+    "        {\"geometry\": Point(3, 9), \"t\": datetime(2018, 1, 1, 12, 6, 0)},\n",
+    "        {\"geometry\": Point(2, 9), \"t\": datetime(2018, 1, 1, 12, 10, 0)},\n",
+    "        {\"geometry\": Point(0, 7), \"t\": datetime(2018, 1, 1, 12, 15, 0)},\n",
+    "    ]\n",
+    ").set_index(\"t\")\n",
     "geo_df = GeoDataFrame(df, crs=31256)\n",
     "toy_traj2 = mpd.Trajectory(geo_df, 1)\n",
     "toy_traj2.df\n",
     "\n",
     "ax = toy_traj.plot()\n",
-    "toy_traj2.plot(ax=ax, color='red')"
+    "toy_traj2.plot(ax=ax, color=\"red\")"
    ]
   },
   {
@@ -99,8 +110,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f'Distance: {toy_traj.distance(toy_traj2)} meters')\n",
-    "print(f'Hausdorff distance: {toy_traj.hausdorff_distance(toy_traj2):.2f} meters')"
+    "print(f\"Distance: {toy_traj.distance(toy_traj2)} meters\")\n",
+    "print(f\"Hausdorff distance: {toy_traj.hausdorff_distance(toy_traj2):.2f} meters\")"
    ]
   },
   {
@@ -112,7 +123,9 @@
    "outputs": [],
    "source": [
     "print(f'Distance: {toy_traj.distance(toy_traj2, units=\"cm\")} cm')\n",
-    "print(f'Hausdorff distance: {toy_traj.hausdorff_distance(toy_traj2, units=\"km\"):.6f} km')"
+    "print(\n",
+    "    f'Hausdorff distance: {toy_traj.hausdorff_distance(toy_traj2, units=\"km\"):.6f} km'\n",
+    ")"
    ]
   },
   {
@@ -130,11 +143,11 @@
    "outputs": [],
    "source": [
     "pt = Point(1, 5)\n",
-    "line = LineString([(3,3), (3,9)])\n",
+    "line = LineString([(3, 3), (3, 9)])\n",
     "\n",
     "ax = toy_traj.plot()\n",
-    "gpd.GeoSeries(pt).plot(ax=ax, color='red')\n",
-    "gpd.GeoSeries(line).plot(ax=ax, color='red')"
+    "gpd.GeoSeries(pt).plot(ax=ax, color=\"red\")\n",
+    "gpd.GeoSeries(line).plot(ax=ax, color=\"red\")"
    ]
   },
   {
@@ -143,8 +156,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f'Distance: {toy_traj.distance(pt)}')\n",
-    "print(f'Hausdorff distance: {toy_traj.hausdorff_distance(pt):.2f}')"
+    "print(f\"Distance: {toy_traj.distance(pt)}\")\n",
+    "print(f\"Hausdorff distance: {toy_traj.hausdorff_distance(pt):.2f}\")"
    ]
   },
   {
@@ -153,8 +166,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(f'Distance: {toy_traj.distance(line)}')\n",
-    "print(f'Hausdorff distance: {toy_traj.hausdorff_distance(line)}')"
+    "print(f\"Distance: {toy_traj.distance(line)}\")\n",
+    "print(f\"Hausdorff distance: {toy_traj.hausdorff_distance(line)}\")"
    ]
   },
   {
@@ -177,7 +190,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -191,7 +204,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/1-tutorials/2-computing-speed.ipynb
+++ b/1-tutorials/2-computing-speed.ipynb
@@ -25,7 +25,7 @@
     "import geopandas as gpd\n",
     "import movingpandas as mpd\n",
     "import shapely as shp\n",
-    "import hvplot.pandas \n",
+    "import hvplot.pandas\n",
     "\n",
     "from geopandas import GeoDataFrame, read_file\n",
     "from shapely.geometry import Point, LineString, Polygon\n",
@@ -33,9 +33,12 @@
     "from holoviews import opts\n",
     "\n",
     "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
     "\n",
-    "opts.defaults(opts.Overlay(active_tools=['wheel_zoom'], frame_width=500, frame_height=400))\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "opts.defaults(\n",
+    "    opts.Overlay(active_tools=[\"wheel_zoom\"], frame_width=500, frame_height=400)\n",
+    ")\n",
     "\n",
     "mpd.show_versions()"
    ]
@@ -53,12 +56,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.DataFrame([\n",
-    "  {'geometry':Point(0,0), 't':datetime(2018,1,1,12,0,0)},\n",
-    "  {'geometry':Point(6,0), 't':datetime(2018,1,1,12,0,6)},\n",
-    "  {'geometry':Point(6,6), 't':datetime(2018,1,1,12,0,11)},\n",
-    "  {'geometry':Point(9,9), 't':datetime(2018,1,1,12,0,14)}\n",
-    "]).set_index('t')\n",
+    "df = pd.DataFrame(\n",
+    "    [\n",
+    "        {\"geometry\": Point(0, 0), \"t\": datetime(2018, 1, 1, 12, 0, 0)},\n",
+    "        {\"geometry\": Point(6, 0), \"t\": datetime(2018, 1, 1, 12, 0, 6)},\n",
+    "        {\"geometry\": Point(6, 6), \"t\": datetime(2018, 1, 1, 12, 0, 11)},\n",
+    "        {\"geometry\": Point(9, 9), \"t\": datetime(2018, 1, 1, 12, 0, 14)},\n",
+    "    ]\n",
+    ").set_index(\"t\")\n",
     "gdf = GeoDataFrame(df, crs=31256)\n",
     "toy_traj = mpd.Trajectory(gdf, 1)\n",
     "toy_traj"
@@ -87,7 +92,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "toy_traj.plot(column=\"speed\", linewidth=5, capstyle='round', legend=True)"
+    "toy_traj.plot(column=\"speed\", linewidth=5, capstyle=\"round\", legend=True)"
    ]
   },
   {
@@ -134,7 +139,9 @@
     "toy_traj.add_distance(overwrite=True, name=\"distance (yards)\", units=\"yd\")\n",
     "toy_traj.add_speed(overwrite=True, name=\"speed (ft/min)\", units=(\"ft\", \"min\"))\n",
     "toy_traj.add_speed(overwrite=True, name=\"speed (knots)\", units=(\"nm\", \"h\"))\n",
-    "toy_traj.add_acceleration(overwrite=True, name=\"acceleration (mph/s)\", units=(\"mi\", \"h\", \"s\"))\n",
+    "toy_traj.add_acceleration(\n",
+    "    overwrite=True, name=\"acceleration (mph/s)\", units=(\"mi\", \"h\", \"s\")\n",
+    ")\n",
     "toy_traj.df"
    ]
   },
@@ -151,8 +158,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gdf = read_file('../data/geolife_small.gpkg')\n",
-    "tc = mpd.TrajectoryCollection(gdf, 'trajectory_id', t='t')"
+    "gdf = read_file(\"../data/geolife_small.gpkg\")\n",
+    "tc = mpd.TrajectoryCollection(gdf, \"trajectory_id\", t=\"t\")"
    ]
   },
   {
@@ -187,7 +194,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_traj.plot(column='speed', linewidth=5, capstyle='round', figsize=(9,3), legend=True, vmax=20)"
+    "my_traj.plot(\n",
+    "    column=\"speed\", linewidth=5, capstyle=\"round\", figsize=(9, 3), legend=True, vmax=20\n",
+    ")"
    ]
   },
   {
@@ -196,7 +205,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_traj.hvplot(c='speed', clim=(0,20), line_width=7.0, tiles='CartoLight', cmap='Viridis', colorbar=True)"
+    "my_traj.hvplot(\n",
+    "    c=\"speed\",\n",
+    "    clim=(0, 20),\n",
+    "    line_width=7.0,\n",
+    "    tiles=\"CartoLight\",\n",
+    "    cmap=\"Viridis\",\n",
+    "    colorbar=True,\n",
+    ")"
    ]
   },
   {
@@ -205,7 +221,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tc.plot(column='speed', linewidth=5, capstyle='round', legend=True, vmax=20)"
+    "tc.plot(column=\"speed\", linewidth=5, capstyle=\"round\", legend=True, vmax=20)"
    ]
   },
   {
@@ -218,7 +234,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -232,7 +248,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/1-tutorials/3-extracting-mover-positions.ipynb
+++ b/1-tutorials/3-extracting-mover-positions.ipynb
@@ -26,7 +26,7 @@
     "import geopandas as gpd\n",
     "import movingpandas as mpd\n",
     "import shapely as shp\n",
-    "import hvplot.pandas \n",
+    "import hvplot.pandas\n",
     "\n",
     "from geopandas import GeoDataFrame, read_file\n",
     "from shapely.geometry import Point, LineString, Polygon\n",
@@ -34,9 +34,12 @@
     "from holoviews import opts\n",
     "\n",
     "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
     "\n",
-    "opts.defaults(opts.Overlay(active_tools=['wheel_zoom'], frame_width=500, frame_height=400))\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "opts.defaults(\n",
+    "    opts.Overlay(active_tools=[\"wheel_zoom\"], frame_width=500, frame_height=400)\n",
+    ")\n",
     "\n",
     "mpd.show_versions()"
    ]
@@ -55,12 +58,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.DataFrame([\n",
-    "  {'geometry':Point(0,0), 't':datetime(2018,1,1,12,0,0)},\n",
-    "  {'geometry':Point(6,0), 't':datetime(2018,1,1,12,6,0)},\n",
-    "  {'geometry':Point(6,6), 't':datetime(2018,1,1,12,10,0)},\n",
-    "  {'geometry':Point(9,9), 't':datetime(2018,1,1,12,15,0)}\n",
-    "]).set_index('t')\n",
+    "df = pd.DataFrame(\n",
+    "    [\n",
+    "        {\"geometry\": Point(0, 0), \"t\": datetime(2018, 1, 1, 12, 0, 0)},\n",
+    "        {\"geometry\": Point(6, 0), \"t\": datetime(2018, 1, 1, 12, 6, 0)},\n",
+    "        {\"geometry\": Point(6, 6), \"t\": datetime(2018, 1, 1, 12, 10, 0)},\n",
+    "        {\"geometry\": Point(9, 9), \"t\": datetime(2018, 1, 1, 12, 15, 0)},\n",
+    "    ]\n",
+    ").set_index(\"t\")\n",
     "gdf = GeoDataFrame(df, crs=31256)\n",
     "toy_traj = mpd.Trajectory(gdf, 1)\n",
     "toy_traj"
@@ -73,8 +78,8 @@
    "outputs": [],
    "source": [
     "ax = toy_traj.plot()\n",
-    "gpd.GeoSeries(toy_traj.get_start_location()).plot(ax=ax, color='blue')\n",
-    "gpd.GeoSeries(toy_traj.get_end_location()).plot(ax=ax, color='red')"
+    "gpd.GeoSeries(toy_traj.get_start_location()).plot(ax=ax, color=\"blue\")\n",
+    "gpd.GeoSeries(toy_traj.get_end_location()).plot(ax=ax, color=\"red\")"
    ]
   },
   {
@@ -99,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "toy_traj.get_position_at(datetime(2018,1,1,12,6,0), method=\"nearest\")    "
+    "toy_traj.get_position_at(datetime(2018, 1, 1, 12, 6, 0), method=\"nearest\")"
    ]
   },
   {
@@ -116,7 +121,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(toy_traj.get_position_at(datetime(2018,1,1,12,6,0), method=\"nearest\"))"
+    "print(toy_traj.get_position_at(datetime(2018, 1, 1, 12, 6, 0), method=\"nearest\"))"
    ]
   },
   {
@@ -144,11 +149,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "t = datetime(2018,1,1,12,7,0)\n",
+    "t = datetime(2018, 1, 1, 12, 7, 0)\n",
     "print(toy_traj.get_position_at(t, method=\"nearest\"))\n",
     "print(toy_traj.get_position_at(t, method=\"interpolated\"))\n",
-    "print(toy_traj.get_position_at(t, method=\"ffill\")) # from the previous row\n",
-    "print(toy_traj.get_position_at(t, method=\"bfill\")) # from the following row"
+    "print(toy_traj.get_position_at(t, method=\"ffill\"))  # from the previous row\n",
+    "print(toy_traj.get_position_at(t, method=\"bfill\"))  # from the following row"
    ]
   },
   {
@@ -160,7 +165,7 @@
     "point = toy_traj.get_position_at(t, method=\"interpolated\")\n",
     "\n",
     "ax = toy_traj.plot()\n",
-    "gpd.GeoSeries(point).plot(ax=ax, color='red', markersize=100)"
+    "gpd.GeoSeries(point).plot(ax=ax, color=\"red\", markersize=100)"
    ]
   },
   {
@@ -179,7 +184,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "segment = toy_traj.get_segment_between(datetime(2018,1,1,12,6,0), datetime(2018,1,1,12,12,0))\n",
+    "segment = toy_traj.get_segment_between(\n",
+    "    datetime(2018, 1, 1, 12, 6, 0), datetime(2018, 1, 1, 12, 12, 0)\n",
+    ")\n",
     "print(segment)"
    ]
   },
@@ -190,7 +197,7 @@
    "outputs": [],
    "source": [
     "ax = toy_traj.plot()\n",
-    "segment.plot(ax=ax, color='red', linewidth=5)"
+    "segment.plot(ax=ax, color=\"red\", linewidth=5)"
    ]
   },
   {
@@ -210,7 +217,9 @@
    "outputs": [],
    "source": [
     "xmin, xmax, ymin, ymax = 2, 8, -10, 5\n",
-    "polygon = Polygon([(xmin, ymin), (xmin, ymax), (xmax, ymax), (xmax, ymin), (xmin, ymin)])\n",
+    "polygon = Polygon(\n",
+    "    [(xmin, ymin), (xmin, ymax), (xmax, ymax), (xmax, ymin), (xmin, ymin)]\n",
+    ")\n",
     "polygon"
    ]
   },
@@ -231,8 +240,8 @@
    "outputs": [],
    "source": [
     "ax = toy_traj.plot()\n",
-    "gpd.GeoSeries(polygon).plot(ax=ax, color='lightgray')\n",
-    "intersections.plot(ax=ax, color='red', linewidth=5, capstyle='round')"
+    "gpd.GeoSeries(polygon).plot(ax=ax, color=\"lightgray\")\n",
+    "intersections.plot(ax=ax, color=\"red\", linewidth=5, capstyle=\"round\")"
    ]
   },
   {
@@ -245,7 +254,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -259,7 +268,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/1-tutorials/4-exporting-trajectories.ipynb
+++ b/1-tutorials/4-exporting-trajectories.ipynb
@@ -26,7 +26,7 @@
     "import geopandas as gpd\n",
     "import movingpandas as mpd\n",
     "import shapely as shp\n",
-    "import hvplot.pandas \n",
+    "import hvplot.pandas\n",
     "\n",
     "from geopandas import GeoDataFrame, read_file\n",
     "from shapely.geometry import Point, LineString, Polygon\n",
@@ -34,9 +34,12 @@
     "from holoviews import opts\n",
     "\n",
     "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
     "\n",
-    "opts.defaults(opts.Overlay(active_tools=['wheel_zoom'], frame_width=500, frame_height=400))\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "opts.defaults(\n",
+    "    opts.Overlay(active_tools=[\"wheel_zoom\"], frame_width=500, frame_height=400)\n",
+    ")\n",
     "\n",
     "mpd.show_versions()"
    ]
@@ -47,8 +50,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gdf = read_file('../data/geolife_small.gpkg')\n",
-    "tc = mpd.TrajectoryCollection(gdf, 'trajectory_id', t='t')\n",
+    "gdf = read_file(\"../data/geolife_small.gpkg\")\n",
+    "tc = mpd.TrajectoryCollection(gdf, \"trajectory_id\", t=\"t\")\n",
     "tc"
    ]
   },
@@ -111,7 +114,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tc.to_traj_gdf(agg={'tracker':'mode', 'sequence':['min', 'max']})"
+    "tc.to_traj_gdf(agg={\"tracker\": \"mode\", \"sequence\": [\"min\", \"max\"]})"
    ]
   },
   {
@@ -136,8 +139,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "export_gdf = tc.to_traj_gdf(agg={'sequence':['min', 'max']})\n",
-    "export_gdf.to_file(\"temp.gpkg\", layer='trajectories', driver=\"GPKG\")"
+    "export_gdf = tc.to_traj_gdf(agg={\"sequence\": [\"min\", \"max\"]})\n",
+    "export_gdf.to_file(\"temp.gpkg\", layer=\"trajectories\", driver=\"GPKG\")"
    ]
   },
   {
@@ -146,7 +149,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "read_file('temp.gpkg').plot()"
+    "read_file(\"temp.gpkg\").plot()"
    ]
   },
   {
@@ -155,7 +158,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "read_file('temp.gpkg')"
+    "read_file(\"temp.gpkg\")"
    ]
   },
   {
@@ -168,7 +171,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -182,7 +185,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/1-tutorials/5-intersecting-with-polygons.ipynb
+++ b/1-tutorials/5-intersecting-with-polygons.ipynb
@@ -270,7 +270,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -284,7 +284,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/1-tutorials/6-splitting-trajectories.ipynb
+++ b/1-tutorials/6-splitting-trajectories.ipynb
@@ -28,7 +28,7 @@
     "import geopandas as gpd\n",
     "import movingpandas as mpd\n",
     "import shapely as shp\n",
-    "import hvplot.pandas \n",
+    "import hvplot.pandas\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from geopandas import GeoDataFrame, read_file\n",
@@ -37,10 +37,13 @@
     "from holoviews import opts\n",
     "\n",
     "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
     "\n",
-    "plot_defaults = {'linewidth':5, 'capstyle':'round', 'figsize':(9,3), 'legend':True}\n",
-    "opts.defaults(opts.Overlay(active_tools=['wheel_zoom'], frame_width=500, frame_height=400))\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "plot_defaults = {\"linewidth\": 5, \"capstyle\": \"round\", \"figsize\": (9, 3), \"legend\": True}\n",
+    "opts.defaults(\n",
+    "    opts.Overlay(active_tools=[\"wheel_zoom\"], frame_width=500, frame_height=400)\n",
+    ")\n",
     "\n",
     "mpd.show_versions()"
    ]
@@ -51,8 +54,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gdf = read_file('../data/geolife_small.gpkg')\n",
-    "tc = mpd.TrajectoryCollection(gdf, 'trajectory_id', t='t')"
+    "gdf = read_file(\"../data/geolife_small.gpkg\")\n",
+    "tc = mpd.TrajectoryCollection(gdf, \"trajectory_id\", t=\"t\")"
    ]
   },
   {
@@ -71,7 +74,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "my_traj.plot(column='speed', vmax=20, **plot_defaults)"
+    "my_traj.plot(column=\"speed\", vmax=20, **plot_defaults)"
    ]
   },
   {
@@ -115,9 +118,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axes = plt.subplots(nrows=1, ncols=len(split), figsize=(19,4))\n",
+    "fig, axes = plt.subplots(nrows=1, ncols=len(split), figsize=(19, 4))\n",
     "for i, traj in enumerate(split):\n",
-    "    traj.plot(ax=axes[i], linewidth=5.0, capstyle='round', column='speed', vmax=20)"
+    "    traj.plot(ax=axes[i], linewidth=5.0, capstyle=\"round\", column=\"speed\", vmax=20)"
    ]
   },
   {
@@ -142,7 +145,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "split = mpd.StopSplitter(my_traj).split(max_diameter=30, min_duration=timedelta(minutes=1), min_length=500)\n",
+    "split = mpd.StopSplitter(my_traj).split(\n",
+    "    max_diameter=30, min_duration=timedelta(minutes=1), min_length=500\n",
+    ")\n",
     "split"
    ]
   },
@@ -161,9 +166,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axes = plt.subplots(nrows=1, ncols=len(split), figsize=(19,4))\n",
+    "fig, axes = plt.subplots(nrows=1, ncols=len(split), figsize=(19, 4))\n",
     "for i, traj in enumerate(split):\n",
-    "    traj.plot(ax=axes[i], linewidth=5.0, capstyle='round', column='speed', vmax=20)"
+    "    traj.plot(ax=axes[i], linewidth=5.0, capstyle=\"round\", column=\"speed\", vmax=20)"
    ]
   },
   {
@@ -207,9 +212,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axes = plt.subplots(nrows=1, ncols=len(split), figsize=(19,4))\n",
+    "fig, axes = plt.subplots(nrows=1, ncols=len(split), figsize=(19, 4))\n",
     "for i, traj in enumerate(split):\n",
-    "    traj.plot(ax=axes[i], linewidth=5.0, capstyle='round', column='speed', vmax=20)"
+    "    traj.plot(ax=axes[i], linewidth=5.0, capstyle=\"round\", column=\"speed\", vmax=20)"
    ]
   },
   {
@@ -222,7 +227,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -236,7 +241,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/1-tutorials/7-generalizing-trajectories.ipynb
+++ b/1-tutorials/7-generalizing-trajectories.ipynb
@@ -34,7 +34,7 @@
     "import geopandas as gpd\n",
     "import movingpandas as mpd\n",
     "import shapely as shp\n",
-    "import hvplot.pandas \n",
+    "import hvplot.pandas\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "from geopandas import GeoDataFrame, read_file\n",
@@ -43,10 +43,13 @@
     "from holoviews import opts\n",
     "\n",
     "import warnings\n",
-    "warnings.filterwarnings('ignore')\n",
     "\n",
-    "plot_defaults = {'linewidth':5, 'capstyle':'round', 'figsize':(9,3), 'legend':True}\n",
-    "opts.defaults(opts.Overlay(active_tools=['wheel_zoom'], frame_width=500, frame_height=400))\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "plot_defaults = {\"linewidth\": 5, \"capstyle\": \"round\", \"figsize\": (9, 3), \"legend\": True}\n",
+    "opts.defaults(\n",
+    "    opts.Overlay(active_tools=[\"wheel_zoom\"], frame_width=500, frame_height=400)\n",
+    ")\n",
     "\n",
     "mpd.show_versions()"
    ]
@@ -57,8 +60,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gdf = read_file('../data/geolife_small.gpkg')\n",
-    "tc = mpd.TrajectoryCollection(gdf, 'trajectory_id', t='t')"
+    "gdf = read_file(\"../data/geolife_small.gpkg\")\n",
+    "tc = mpd.TrajectoryCollection(gdf, \"trajectory_id\", t=\"t\")"
    ]
   },
   {
@@ -77,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "original_traj.plot(column='speed', vmax=20, **plot_defaults)"
+    "original_traj.plot(column=\"speed\", vmax=20, **plot_defaults)"
    ]
   },
   {
@@ -102,8 +105,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dp_generalized  = mpd.DouglasPeuckerGeneralizer(original_traj).generalize(tolerance=0.001)\n",
-    "dp_generalized.plot(column='speed', vmax=20, **plot_defaults)"
+    "dp_generalized = mpd.DouglasPeuckerGeneralizer(original_traj).generalize(\n",
+    "    tolerance=0.001\n",
+    ")\n",
+    "dp_generalized.plot(column=\"speed\", vmax=20, **plot_defaults)"
    ]
   },
   {
@@ -112,7 +117,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dp_generalized "
+    "dp_generalized"
    ]
   },
   {
@@ -121,8 +126,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print('Original length: %s'%(original_traj.get_length()))\n",
-    "print('Generalized length: %s'%(dp_generalized.get_length()))"
+    "print(\"Original length: %s\" % (original_traj.get_length()))\n",
+    "print(\"Generalized length: %s\" % (dp_generalized.get_length()))"
    ]
   },
   {
@@ -141,8 +146,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "time_generalized = mpd.MinTimeDeltaGeneralizer(original_traj).generalize(tolerance=timedelta(minutes=1))\n",
-    "time_generalized.plot(column='speed', vmax=20, **plot_defaults)"
+    "time_generalized = mpd.MinTimeDeltaGeneralizer(original_traj).generalize(\n",
+    "    tolerance=timedelta(minutes=1)\n",
+    ")\n",
+    "time_generalized.plot(column=\"speed\", vmax=20, **plot_defaults)"
    ]
   },
   {
@@ -177,7 +184,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tdtr_generalized = mpd.TopDownTimeRatioGeneralizer(original_traj).generalize(tolerance=0.001)"
+    "tdtr_generalized = mpd.TopDownTimeRatioGeneralizer(original_traj).generalize(\n",
+    "    tolerance=0.001\n",
+    ")"
    ]
   },
   {
@@ -194,9 +203,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(19,4))\n",
-    "tdtr_generalized.plot(ax=axes[0], column='speed', vmax=20, **plot_defaults)\n",
-    "dp_generalized.plot(ax=axes[1], column='speed', vmax=20, **plot_defaults)"
+    "fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(19, 4))\n",
+    "tdtr_generalized.plot(ax=axes[0], column=\"speed\", vmax=20, **plot_defaults)\n",
+    "dp_generalized.plot(ax=axes[1], column=\"speed\", vmax=20, **plot_defaults)"
    ]
   },
   {
@@ -212,9 +221,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(19,4))\n",
-    "tdtr_generalized.plot(ax=axes[0], column='speed', vmax=20, **plot_defaults)\n",
-    "time_generalized.plot(ax=axes[1], column='speed', vmax=20, **plot_defaults)"
+    "fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(19, 4))\n",
+    "tdtr_generalized.plot(ax=axes[0], column=\"speed\", vmax=20, **plot_defaults)\n",
+    "time_generalized.plot(ax=axes[1], column=\"speed\", vmax=20, **plot_defaults)"
    ]
   },
   {
@@ -227,7 +236,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -241,7 +250,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/1-tutorials/8-detecting-stops.ipynb
+++ b/1-tutorials/8-detecting-stops.ipynb
@@ -424,7 +424,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -438,7 +438,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/1-tutorials/9-aggregating-trajectories.ipynb
+++ b/1-tutorials/9-aggregating-trajectories.ipynb
@@ -69,7 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tc.hvplot(line_width=7.0, tiles=\"StamenTonerBackground\")"
+    "tc.hvplot(line_width=7.0, tiles=\"CartoLight\")"
    ]
   },
   {
@@ -128,10 +128,7 @@
    "source": [
     "pts = aggregator.get_significant_points_gdf()\n",
     "clusters = aggregator.get_clusters_gdf()\n",
-    "(\n",
-    "    pts.hvplot(geo=True, tiles=\"StamenTonerBackground\")\n",
-    "    * clusters.hvplot(geo=True, color=\"red\")\n",
-    ")"
+    "(pts.hvplot(geo=True, tiles=\"CartoLight\") * clusters.hvplot(geo=True, color=\"red\"))"
    ]
   },
   {
@@ -171,7 +168,7 @@
     "        hover_cols=[\"weight\"],\n",
     "        line_width=dim(\"weight\") * 7,\n",
     "        color=\"#1f77b3\",\n",
-    "        tiles=\"StamenTonerBackground\",\n",
+    "        tiles=\"CartoLight\",\n",
     "    )\n",
     "    * clusters.hvplot(geo=True, color=\"red\", size=dim(\"n\"))\n",
     ")"
@@ -211,7 +208,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -225,7 +222,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/1-tutorials/99-mini-example.ipynb
+++ b/1-tutorials/99-mini-example.ipynb
@@ -220,7 +220,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -234,7 +234,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/2-analysis-examples/bird-migration.ipynb
+++ b/2-analysis-examples/bird-migration.ipynb
@@ -478,7 +478,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -492,7 +492,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/2-analysis-examples/ever-given.ipynb
+++ b/2-analysis-examples/ever-given.ipynb
@@ -224,7 +224,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -238,12 +238,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "2fad62c144698ee51b1d31172f8302cb858a7bff343bd84b86812f8129ff7fd2"
-   }
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/2-analysis-examples/horse-collar.ipynb
+++ b/2-analysis-examples/horse-collar.ipynb
@@ -1028,7 +1028,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -1042,7 +1042,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/2-analysis-examples/iceberg.ipynb
+++ b/2-analysis-examples/iceberg.ipynb
@@ -205,7 +205,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -219,12 +219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "2fad62c144698ee51b1d31172f8302cb858a7bff343bd84b86812f8129ff7fd2"
-   }
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/2-analysis-examples/mars-rover.ipynb
+++ b/2-analysis-examples/mars-rover.ipynb
@@ -296,7 +296,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -310,7 +310,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/2-analysis-examples/osm-traces.ipynb
+++ b/2-analysis-examples/osm-traces.ipynb
@@ -217,7 +217,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -231,7 +231,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/2-analysis-examples/pollution-data.ipynb
+++ b/2-analysis-examples/pollution-data.ipynb
@@ -303,7 +303,7 @@
    "source": [
     "res = 7\n",
     "point_gdf[\"h3_cell\"] = point_gdf.apply(\n",
-    "    lambda r: str(h3.geo_to_h3(r.y, r.x, res)), axis=1\n",
+    "    lambda r: str(h3.latlng_to_cell(r.y, r.x, res)), axis=1\n",
     ")\n",
     "point_gdf.head()"
    ]
@@ -365,7 +365,7 @@
    "outputs": [],
    "source": [
     "def cell_to_shapely(cell):\n",
-    "    coords = h3.h3_to_geo_boundary(cell)\n",
+    "    coords = h3.cell_to_boundary(cell)\n",
     "    flipped = tuple(coord[::-1] for coord in coords)\n",
     "    return Polygon(flipped)\n",
     "\n",
@@ -478,7 +478,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "movingpandas",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -492,7 +492,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/2-analysis-examples/ship-data.ipynb
+++ b/2-analysis-examples/ship-data.ipynb
@@ -861,7 +861,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -875,7 +875,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/2-analysis-examples/soccer-game.ipynb
+++ b/2-analysis-examples/soccer-game.ipynb
@@ -382,7 +382,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "mpd-ex",
    "language": "python",
    "name": "python3"
   },
@@ -396,7 +396,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.14"
+   "version": "3.10.15"
   }
  },
  "nbformat": 4,

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: mpd-ex
 channels:
   - conda-forge
 dependencies:
-  - python>=3.12
+  - python=3.10
   - notebook
   - ipykernel
   - jupyter_client<8
@@ -13,3 +13,4 @@ dependencies:
   - hvplot
   - h3-py
   - stonesoup
+  - numpy=1.23.1


### PR DESCRIPTION
Issues with updating to movingpandas=0.20 and python=3.12:
- "import hvplot.pandas" and "from holoviews import opts" did not work and required numpy=1.23.1
- numpy=1.23.1 does not work with python=3.12 

Solution: 
- environment.yml specify python=3.10 and numpy=1.23.1